### PR TITLE
CPU例外の番号を変更

### DIFF
--- a/arch/arm_m_gcc/common/core_test.h
+++ b/arch/arm_m_gcc/common/core_test.h
@@ -50,7 +50,7 @@
 /*
  *  チップで共通な定義
  */
-#define CPUEXC1 3   /* Hard Fault */
+#define CPUEXC1 6   /* Usage Fault */
 #define RAISE_CPU_EXCEPTION {   \
     Asm("mov r0, #0x00");       \
     Asm("push {r0}");           \

--- a/arch/arm_m_gcc/common/core_test.h
+++ b/arch/arm_m_gcc/common/core_test.h
@@ -51,12 +51,6 @@
  *  チップで共通な定義
  */
 #define CPUEXC1 6   /* Usage Fault */
-#define RAISE_CPU_EXCEPTION {   \
-    Asm("mov r0, #0x00");       \
-    Asm("push {r0}");           \
-    Asm("pop  {pc}");           \
-}
-#define CANNOT_RETURN_CPUEXC
-
+#define RAISE_CPU_EXCEPTION Asm("udf #0")
 
 #endif /* TOPPERS_CORE_TEST_H */


### PR DESCRIPTION
CPU例外の番号は6であるべきな気がします．sample1で動作確認しています．
arch/arm_m_gcc/common の修正なので，これも @exshonda さんのご意見を伺いたいですm(_ _)m
（そもそもTracでやるべき？？

---
修正前：
```
System logging task is started.
Sample program starts (exinf = 0).
task1 is running (001).   |
task1 is running (002).   |
task1 is running (003).   |
task1 is running (004).   |
('z'を入力)

Unregistered Exception occurs.
Excno = 00000006 PC = 00000000 XPSR = 40000000 basepri = 00000000, p_excinf = 20001B88
```

修正後：
```
System logging task is started.
Sample program starts (exinf = 0).
task1 is running (001).   |
task1 is running (002).   |
task1 is running (003).   |
task1 is running (004).   |
('z'を入力)
CPU exception handler (p_excinf = 20001b88).
sns_loc = 0, sns_dsp = 0, xsns_dpn = 0
task2 is running (001).     +
task2 is running (002).     +
task2 is running (003).     +
task2 is running (004).     +
('2'+'Z'を入力)
-- buffered messages --
CPU exception handler (p_excinf = 20001f88).
sns_loc = 1, sns_dsp = 0, xsns_dpn = 1
Sample program ends with exception.
```